### PR TITLE
[Feature] Add expenditure history by category get api

### DIFF
--- a/src/backend/controllers/account-history.js
+++ b/src/backend/controllers/account-history.js
@@ -47,6 +47,17 @@ const AccountHistoryController = {
     });
   },
 
+  getCategory(req, res) {
+    const {id} = req.params;
+    const {startYear, startMonth, endYear, endMonth} = req.query;
+    const startDate = `${startYear}.${startMonth}.01`;
+    const endDate = `${endYear}.${endMonth}.31`;
+
+    AccountHistoryService.getCategory({id, startDate, endDate}, categories => {
+      res.status(200).send(categories);
+    });
+  },
+
   getPayments(req, res) {
     AccountHistoryService.getPayments(payments => {
       res.status(200).send(payments);

--- a/src/backend/query-statements/account-history.js
+++ b/src/backend/query-statements/account-history.js
@@ -78,6 +78,14 @@ order by type desc, id
 `;
   },
 
+  getCategoryQuery: () => `
+    select HC.yearMonthString, sum(HC.price) as total from (select left(ACCOUNT_HISTORY.dateString, 7) as yearMonthString, ACCOUNT_HISTORY.categoryId, ACCOUNT_HISTORY.price
+    from ACCOUNT_HISTORY inner join ACCOUNT_HISTORY_CATEGORY
+    on ACCOUNT_HISTORY.categoryId = ACCOUNT_HISTORY_CATEGORY.id
+    where ACCOUNT_HISTORY.categoryId = ? and ACCOUNT_HISTORY.dateString >= ? and ACCOUNT_HISTORY.dateString <= ?) HC
+    group by HC.yearMonthString
+  `,
+
   getPaymentsQuery: () => `select id, title from PAYMENT`,
 
   createPaymentQuery: () => `insert into PAYMENT (title) values (?);`,

--- a/src/backend/routes/account-history.js
+++ b/src/backend/routes/account-history.js
@@ -7,6 +7,7 @@ router.get('/', AccountHistoryController.getList);
 router.post('/', AccountHistoryController.createHistory);
 router.put('/:id', AccountHistoryController.updateHistory);
 router.get('/categories', AccountHistoryController.getCategories);
+router.get('/categories/:id', AccountHistoryController.getCategory);
 router.get('/payments', AccountHistoryController.getPayments);
 router.post('/payments', AccountHistoryController.createPayment);
 router.delete('/payments/:id', AccountHistoryController.deletePayment);

--- a/src/backend/services/account-history.js
+++ b/src/backend/services/account-history.js
@@ -7,6 +7,7 @@ const {
   getPaymentsQuery,
   createPaymentQuery,
   deletePaymentQuery,
+  getCategoryQuery,
 } = require('../query-statements/account-history.js');
 const {getHistoryResult} = require('./utils/account-history.js');
 
@@ -63,6 +64,21 @@ const AccountHistoryService = {
           expenditure: [],
         },
       );
+      resCallback(result);
+    });
+  },
+
+  getCategory({id, startDate, endDate}, resCallback) {
+    const sql = getCategoryQuery();
+    dbPool.query(sql, [id, startDate, endDate], (err, monthData) => {
+      const result = monthData.map(({yearMonthString, total}) => {
+        const [yearString, monthString] = yearMonthString.split('.');
+        return {
+          year: Number(yearString),
+          month: Number(monthString),
+          total: Number(total),
+        };
+      });
       resCallback(result);
     });
   },

--- a/src/frontend/api/history.js
+++ b/src/frontend/api/history.js
@@ -1,5 +1,5 @@
 import API from './index.js';
-import { getQueryString } from '../utils/api.js';
+import {getQueryString} from '../utils/api.js';
 
 const AccountHistoryAPI = {
   getList: filter => {
@@ -12,9 +12,13 @@ const AccountHistoryAPI = {
     const queryString = getQueryString(filter);
     return API.get(`/api/account-history/categories${queryString}`);
   },
+  getCategory: (id, filter = {}) => {
+    const queryString = getQueryString(filter);
+    return API.get(`/api/account-history/categories/${id}${queryString}`);
+  },
   getPayments: () => API.get('/api/account-history/payments'),
-  postPayment: (body) => API.post('/api/account-history/payments', body),
-  deletePayment: (id) => API.delete(`/api/account-history/payments/${id}`),
+  postPayment: body => API.post('/api/account-history/payments', body),
+  deletePayment: id => API.delete(`/api/account-history/payments/${id}`),
 };
 
 export default AccountHistoryAPI;


### PR DESCRIPTION
## Description

카테고리별 최근 6개월 지출내역을 get하는 API를 추가합니다.

## Related Issues

resolve #31 

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] Issue TODO finished
- [x] No Conflicts with the base branch
