### PR TITLE
[Feature] Disable adder submit btn when form value is same with prev value

### DIFF
--- a/src/frontend/components/account-history/detail-adder/index.js
+++ b/src/frontend/components/account-history/detail-adder/index.js
@@ -46,18 +46,65 @@ export default class AccountHistoryDetailAdder {
     const $paymentSelect = this.$target.querySelector('select[name="payment"]');
     const $priceInput = this.$target.querySelector('input[name="price"]');
 
+    const isFormValid = ({dateString, categoryId, description, paymentId, price}) =>
+      dateString.length !== 8 || !categoryId || !description || !paymentId || !price;
+
+    const isFormNotChanged = ({
+      dateString,
+      categoryId,
+      description,
+      paymentId,
+      price,
+      defaultDateString,
+      defaultCategoryId,
+      defaultDescription,
+      defaultPaymentId,
+      defaultPrice,
+    }) =>
+      dateString === defaultDateString &&
+      categoryId === defaultCategoryId &&
+      description === defaultDescription &&
+      paymentId === defaultPaymentId &&
+      price === defaultPrice;
+
     this.$target.addEventListener('input', () => {
-      if (
-        $dateStringInput.value.length !== 8 ||
-        !$categorySelect.value ||
-        !$descriptionInput.value ||
-        !$paymentSelect.value ||
-        !$priceInput.value
-      ) {
-        $submitBtn.disabled = true;
-        return;
-      }
-      $submitBtn.disabled = false;
+      const {
+        value: dateString,
+        dataset: {defaultValue: defaultDateString},
+      } = $dateStringInput;
+      const {
+        value: categoryId,
+        dataset: {defaultValue: defaultCategoryId},
+      } = $categorySelect;
+      const {
+        value: description,
+        dataset: {defaultValue: defaultDescription},
+      } = $descriptionInput;
+      const {
+        value: paymentId,
+        dataset: {defaultValue: defaultPaymentId},
+      } = $paymentSelect;
+      const {
+        value: price,
+        dataset: {defaultValue: defaultPrice},
+      } = $priceInput;
+
+      $submitBtn.disabled =
+        isFormValid({dateString, categoryId, description, paymentId, price}) ||
+        (this.$target.dataset.id &&
+          isFormNotChanged({
+            dateString,
+            categoryId,
+            description,
+            paymentId,
+            price,
+            defaultDateString,
+            defaultCategoryId,
+            defaultDescription,
+            defaultPaymentId,
+            defaultPrice,
+          })) ||
+        false;
     });
 
     this.$target.addEventListener('click', e => {

--- a/src/frontend/components/account-history/detail-list/index.js
+++ b/src/frontend/components/account-history/detail-list/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 import AccountHistoryDetailListByDate from './by-date/index.js';
 import AccountHistoryDetailListHeader from './header/index.js';
 
@@ -27,6 +28,11 @@ export default class AccountHistoryDetailList {
       history: {dates},
     } = this.model.getData();
 
+    const setDefaultValue = ($elem, defaultValue) => {
+      $elem.dataset.defaultValue = defaultValue;
+      $elem.value = defaultValue;
+    };
+
     this.$target.addEventListener('click', e => {
       const $detailRow = e.target.closest('.history-detail-list-by-date-detail');
       if (!$detailRow) return;
@@ -44,11 +50,11 @@ export default class AccountHistoryDetailList {
       const detail = details[detailIndex];
       const {category, description, payment, price} = detail;
       $detailAdder.dataset.id = detailId;
-      $dateStringInput.value = getNumString(dateString);
-      $categorySelect.value = category.id;
-      $descriptionInput.value = description;
-      $paymentSelect.value = payment.id;
-      $priceInput.value = price.toLocaleString();
+      setDefaultValue($dateStringInput, getNumString(dateString));
+      setDefaultValue($categorySelect, category.id);
+      setDefaultValue($descriptionInput, description);
+      setDefaultValue($paymentSelect, payment.id);
+      setDefaultValue($priceInput, price.toLocaleString());
 
       updateCategoryTypeToggleBtn(category.type);
 


### PR DESCRIPTION
## Description

수입/지출 내역 수정 시 기존 폼 값과 비교하여 같을 때 제출 버튼을 비활성화하는 로직을 추가합니다.

## Related Issues

resolve #34 

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] Issue TODO finished
- [x] No Conflicts with the base branch
