### PR TITLE
[Bugfix] Make detail adder input value not disappear when add or delete payment

### DIFF
--- a/src/frontend/components/account-history/detail-adder/Select.js
+++ b/src/frontend/components/account-history/detail-adder/Select.js
@@ -16,6 +16,9 @@ export default class AccountHistoryDetailAdderSelect {
     if (this.state.name === 'payment') {
       this.model.subscribe('payments', this.render.bind(this));
     }
+    if (this.state.name === 'category') {
+      this.model.subscribe('categories', this.render.bind(this));
+    }
 
     this.render();
     this.handleEvent();
@@ -64,9 +67,11 @@ export default class AccountHistoryDetailAdderSelect {
     });
 
     this.$target.addEventListener('input', e => {
-      const {value} = e.target;
+      const {tagName, value} = e.target;
+      if (tagName === 'INPUT') return;
       const $selectLabel = this.$target.querySelector('.select-selected');
-      $selectLabel.style.color = COLORS.TITLE_ACTIVE;
+      $selectLabel.style.color = value ? COLORS.TITLE_ACTIVE : COLORS.LABEL;
+      if (!value) $selectLabel.innerText = '선택하세요';
       closeSelect();
       [...this.$target.querySelectorAll('div.select-item')].forEach($elem => {
         const {optionValue, optionTitle} = $elem.dataset;

--- a/src/frontend/components/account-history/detail-adder/index.js
+++ b/src/frontend/components/account-history/detail-adder/index.js
@@ -68,6 +68,10 @@ export default class AccountHistoryDetailAdder {
       paymentId === defaultPaymentId &&
       price === defaultPrice;
 
+    this.$target.addEventListener('input', e => {
+      if (e.target.id === 'confirm-modal-input') {
+        return;
+      }
       const {$dateStringInput, $categorySelect, $descriptionInput, $paymentSelect, $priceInput} =
         getHistoryDetailAdderItems(this.$target);
       const {

--- a/src/frontend/components/account-history/detail-adder/index.js
+++ b/src/frontend/components/account-history/detail-adder/index.js
@@ -127,7 +127,7 @@ export default class AccountHistoryDetailAdder {
       const dateString = addDot($dateStringInput.value);
       const categoryId = +$categorySelect.value;
       const description = $descriptionInput.value;
-      const paymentId = +$paymentSelect.value;
+      const paymentId = +$paymentSelect.value || null;
       const price = +getNumString($priceInput.value);
 
       this.formData = {

--- a/src/frontend/components/account-history/detail-adder/index.js
+++ b/src/frontend/components/account-history/detail-adder/index.js
@@ -42,13 +42,6 @@ export default class AccountHistoryDetailAdder {
   }
 
   handleEvent() {
-    const $submitBtn = this.$target.querySelector('.history-detail-adder-submitBtn');
-    const $dateStringInput = this.$target.querySelector('input[name="dateString"]');
-    const $categorySelect = this.$target.querySelector('select[name="category"]');
-    const $descriptionInput = this.$target.querySelector('input[name="description"]');
-    const $paymentSelect = this.$target.querySelector('select[name="payment"]');
-    const $priceInput = this.$target.querySelector('input[name="price"]');
-
     const isFormValid = ({dateString, categoryId, description, paymentId, price}) =>
       dateString.length === 8 &&
       categoryId &&
@@ -74,7 +67,8 @@ export default class AccountHistoryDetailAdder {
       paymentId === defaultPaymentId &&
       price === defaultPrice;
 
-    this.$target.addEventListener('input', () => {
+      const {$dateStringInput, $categorySelect, $descriptionInput, $paymentSelect, $priceInput} =
+        getHistoryDetailAdderItems(this.$target);
       const {
         value: dateString,
         dataset: {defaultValue: defaultDateString},
@@ -96,6 +90,7 @@ export default class AccountHistoryDetailAdder {
         dataset: {defaultValue: defaultPrice},
       } = $priceInput;
 
+      const $submitBtn = this.$target.querySelector('.history-detail-adder-submitBtn');
       $submitBtn.disabled =
         !isFormValid({dateString, categoryId, description, paymentId, price}) ||
         (this.$target.dataset.id &&
@@ -126,6 +121,8 @@ export default class AccountHistoryDetailAdder {
       const $submitBtn = e.target.closest('.history-detail-adder-submitBtn');
       if (!$submitBtn) return;
 
+      const {$dateStringInput, $categorySelect, $descriptionInput, $paymentSelect, $priceInput} =
+        getHistoryDetailAdderItems(this.$target);
       const dateString = addDot($dateStringInput.value);
       const categoryId = +$categorySelect.value;
       const description = $descriptionInput.value;

--- a/src/frontend/components/account-history/detail-adder/index.js
+++ b/src/frontend/components/account-history/detail-adder/index.js
@@ -6,6 +6,7 @@ import {updateCategoryTypeToggleBtn} from '../../../utils/category.js';
 import AccountHistoryDetailAdderItem from './Item.js';
 import AccountHistoryDetailAdderSubmitBtn from './SubmitBtn.js';
 import {showLoadingIndicator, hideLoadingIndicator} from '../../../utils/loading.js';
+import {getHistoryDetailAdderItems, resetHistoryDetailAdderForm} from '../../../utils/history.js';
 
 const ADDER_ITEM_DATA = [
   {label: '일자', name: 'dateString', itemType: 'input'},
@@ -44,11 +45,7 @@ export default class AccountHistoryDetailAdder {
 
   handleEvent() {
     const isFormValid = ({dateString, categoryId, description, paymentId, price}) =>
-      dateString.length === 8 &&
-      categoryId &&
-      description &&
-      ($paymentSelect.dataset.defaultValue === '' || paymentId) &&
-      price;
+      dateString.length === 8 && categoryId && description && paymentId && price;
 
     const isFormNotChanged = ({
       dateString,
@@ -97,7 +94,13 @@ export default class AccountHistoryDetailAdder {
 
       const $submitBtn = this.$target.querySelector('.history-detail-adder-submitBtn');
       $submitBtn.disabled =
-        !isFormValid({dateString, categoryId, description, paymentId, price}) ||
+        !isFormValid({
+          dateString,
+          categoryId,
+          description,
+          paymentId: $paymentSelect.dataset.defaultValue === '' || paymentId,
+          price,
+        }) ||
         (this.$target.dataset.id &&
           isFormNotChanged({
             dateString,

--- a/src/frontend/components/account-history/detail-adder/index.js
+++ b/src/frontend/components/account-history/detail-adder/index.js
@@ -120,7 +120,7 @@ export default class AccountHistoryDetailAdder {
       }
 
       const $submitBtn = e.target.closest('.history-detail-adder-submitBtn');
-      if (!$submitBtn) return;
+      if (!$submitBtn || $submitBtn.disabled) return;
 
       const {$dateStringInput, $categorySelect, $descriptionInput, $paymentSelect, $priceInput} =
         getHistoryDetailAdderItems(this.$target);

--- a/src/frontend/components/account-history/detail-adder/index.js
+++ b/src/frontend/components/account-history/detail-adder/index.js
@@ -35,6 +35,7 @@ export default class AccountHistoryDetailAdder {
       showLoadingIndicator();
       await submit();
       await this.model.onHistoryMutate();
+      resetHistoryDetailAdderForm();
       hideLoadingIndicator();
     } catch (err) {
       alert(`수입/지출 내역 ${id === undefined ? '추가' : '수정'} 요청이 실패했습니다.`);

--- a/src/frontend/components/account-history/detail-list/index.js
+++ b/src/frontend/components/account-history/detail-list/index.js
@@ -4,6 +4,7 @@ import AccountHistoryDetailListHeader from './header/index.js';
 
 import {updateCategoryTypeToggleBtn} from '../../../utils/category.js';
 import {getNumString} from '../../../utils/string.js';
+import {setHistoryDetailAdderForm, dispatchInputEventToAdderSelects} from '../../../utils/history.js';
 
 export default class AccountHistoryDetailList {
   constructor({$parent, model}) {
@@ -12,6 +13,8 @@ export default class AccountHistoryDetailList {
 
     $parent.appendChild(this.$target);
     this.model = model;
+    this.model.subscribe('payments', this.render.bind(this));
+    this.model.subscribe('history', this.render.bind(this));
 
     this.render();
     this.handleEvent();
@@ -52,6 +55,7 @@ export default class AccountHistoryDetailList {
   }
 
   render() {
+    this.$target.innerHTML = '';
     new AccountHistoryDetailListHeader({$parent: this.$target, model: this.model});
     const {dates} = this.model.get('history');
     dates.forEach(date => {

--- a/src/frontend/components/account-history/detail-list/index.js
+++ b/src/frontend/components/account-history/detail-list/index.js
@@ -18,25 +18,13 @@ export default class AccountHistoryDetailList {
   }
 
   handleEvent() {
-    const $detailAdder = document.querySelector('.history-detail-adder');
-    const $dateStringInput = $detailAdder.querySelector('input[name="dateString"]');
-    const $categorySelect = $detailAdder.querySelector('select[name="category"]');
-    const $descriptionInput = $detailAdder.querySelector('input[name="description"]');
-    const $paymentSelect = $detailAdder.querySelector('select[name="payment"]');
-    const $priceInput = $detailAdder.querySelector('input[name="price"]');
-    const {dates} = this.model.get('history');
-
-    const setDefaultValue = ($elem, defaultValue) => {
-      $elem.dataset.defaultValue = defaultValue;
-      $elem.value = defaultValue;
-    };
-
     this.$target.addEventListener('click', e => {
       const $detailRow = e.target.closest('.history-detail-list-by-date-detail');
       if (!$detailRow) return;
       const {id} = $detailRow.dataset;
       const detailId = +id;
       let detailIndex = -1;
+      const {dates} = this.model.get('history');
       const dateIndex = dates.findIndex(({details}) => {
         const dIndex = details.findIndex(v => v.id === detailId);
         if (dIndex === -1) return false;
@@ -47,17 +35,14 @@ export default class AccountHistoryDetailList {
       const {dateString, details} = dates[dateIndex];
       const detail = details[detailIndex];
       const {category, description, payment, price} = detail;
-      $detailAdder.dataset.id = detailId;
-      setDefaultValue($dateStringInput, getNumString(dateString));
-      setDefaultValue($categorySelect, category.id);
-      setDefaultValue($descriptionInput, description);
-      setDefaultValue($paymentSelect, payment.id || '');
-      setDefaultValue($priceInput, price.toLocaleString());
 
-      updateCategoryTypeToggleBtn(category.type);
-
-      const event = new Event('input', {
-        bubbles: true,
+      setHistoryDetailAdderForm({
+        id: detailId,
+        dateString: getNumString(dateString),
+        categoryId: category.id,
+        description,
+        paymentId: payment.id || '',
+        price: price.toLocaleString(),
       });
       $categorySelect.dispatchEvent(event);
       $paymentSelect.dispatchEvent(event);

--- a/src/frontend/components/account-history/detail-list/index.js
+++ b/src/frontend/components/account-history/detail-list/index.js
@@ -44,8 +44,8 @@ export default class AccountHistoryDetailList {
         paymentId: payment.id || '',
         price: price.toLocaleString(),
       });
-      $categorySelect.dispatchEvent(event);
-      $paymentSelect.dispatchEvent(event);
+      updateCategoryTypeToggleBtn(category.type);
+      dispatchInputEventToAdderSelects();
 
       window.scrollTo({top: 0, behavior: 'smooth'});
     });

--- a/src/frontend/stylesheets/detail.css
+++ b/src/frontend/stylesheets/detail.css
@@ -19,25 +19,25 @@
   border-left: 1px solid var(--placeholder-color);
 }
 
-.history-detail-adder-item>label {
+.history-detail-adder-item > label {
   color: var(--primary-color-3);
   font-weight: 700;
   font-size: 1.2rem;
   margin-bottom: 0.4rem;
 }
 
-.history-detail-adder-input-wrapper>input {
+.history-detail-adder-input-wrapper > input {
   border: none;
   font-size: 1.6rem;
   background: none;
 }
 
-.history-detail-adder-input-wrapper>input[name='dateString'],
-.history-detail-adder-input-wrapper>input[name='price'] {
+.history-detail-adder-input-wrapper > input[name='dateString'],
+.history-detail-adder-input-wrapper > input[name='price'] {
   width: 8rem;
 }
 
-.history-detail-adder-input-wrapper>input[name='description'] {
+.history-detail-adder-input-wrapper > input[name='description'] {
   width: 18.8rem;
 }
 
@@ -52,17 +52,17 @@
   margin-right: 1.2rem;
 }
 
-.category-type-toggleBtn>img {
+.category-type-toggleBtn > img {
   width: 1.2rem;
   height: 1.2rem;
 }
 
-.history-detail-adder-input-wrapper>p {
+.history-detail-adder-input-wrapper > p {
   margin-left: 1.2rem;
   font-size: 1.6rem;
 }
 
-.history-detail-adder-input-wrapper>input[name='price'] {
+.history-detail-adder-input-wrapper > input[name='price'] {
   text-align: right;
 }
 
@@ -92,12 +92,12 @@
   width: 0;
   height: 0;
   border: 6px solid transparent;
-  border-color: var(--title-active-color) transparent transparent transparent;
+  border-color: var(--label-color) transparent transparent transparent;
 }
 
 /* Point the arrow upwards when the select box is open (active): */
 .select-selected.select-arrow-active:after {
-  border-color: transparent transparent var(--title-active-color) transparent;
+  border-color: transparent transparent var(--label-color) transparent;
   top: 0.4rem;
 }
 
@@ -157,15 +157,15 @@ button.select-item {
   border-radius: 1rem;
 }
 
-.history-detail-adder-submitBtn>img {
-  filter: invert(100%) sepia(0%) saturate(7500%) hue-rotate(4deg) brightness(101%) contrast(101%);
+.history-detail-adder-submitBtn > img {
+  filter: invert(100%) sepia(100%) saturate(0%) hue-rotate(76deg) brightness(103%) contrast(101%);
 }
 
 .history-detail-adder-submitBtn:disabled {
   background: none;
 }
 
-.history-detail-adder-submitBtn:disabled>img {
+.history-detail-adder-submitBtn:disabled > img {
   filter: invert(65%) sepia(60%) saturate(519%) hue-rotate(129deg) brightness(89%) contrast(86%);
 }
 
@@ -191,16 +191,16 @@ button.select-item {
   font-size: 1.8rem;
 }
 
-.history-detail-list-filter-item>input {
+.history-detail-list-filter-item > input {
   display: none;
 }
 
-.history-detail-list-filter-item>label {
+.history-detail-list-filter-item > label {
   display: flex;
   align-items: center;
 }
 
-.history-detail-list-filter-item>label>span {
+.history-detail-list-filter-item > label > span {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -212,18 +212,18 @@ button.select-item {
   border-radius: 0.5rem;
 }
 
-.history-detail-list-filter-item>label>span.checked {
+.history-detail-list-filter-item > label > span.checked {
   background-color: var(--primary-color-1);
 }
 
-.history-detail-list-filter-item>label>span>img {
+.history-detail-list-filter-item > label > span > img {
   filter: invert(65%) sepia(60%) saturate(519%) hue-rotate(129deg) brightness(89%) contrast(86%);
   width: 1.4rem;
   height: 1.4rem;
 }
 
-.history-detail-list-filter-item>label>span.checked>img {
-  filter: invert(100%) sepia(0%) saturate(7500%) hue-rotate(4deg) brightness(101%) contrast(101%);
+.history-detail-list-filter-item > label > span.checked > img {
+  filter: invert(100%) sepia(100%) saturate(0%) hue-rotate(76deg) brightness(103%) contrast(101%);
 }
 
 .history-detail-list-by-date-header {
@@ -245,13 +245,16 @@ button.select-item {
   color: var(--title-active-color);
 }
 
+.history-detail-list-wrapper {
+  cursor: pointer;
+}
+
 .history-detail-list-by-date-detail {
   display: flex;
   align-items: center;
   padding: 2rem 0.8rem;
   border-bottom: 1px solid var(--line-color);
   font-size: 1.8rem;
-  cursor: pointer;
 }
 
 .history-detail-list-by-date-detail p.category-title {
@@ -320,13 +323,13 @@ button.select-item {
   margin-bottom: 4rem;
 }
 
-#confirm-modal-input::placeholder {
-  color: var(--placeholder-color)
+input::placeholder {
+  color: var(--label-color);
 }
 
 #confirm-modal-input:focus {
   outline: none;
-  border-color: var(--primary-color-1)
+  border-color: var(--primary-color-1);
 }
 
 .confirm-modal-btns-wrapper {
@@ -335,16 +338,15 @@ button.select-item {
   justify-content: space-between;
 }
 
-.confirm-modal-btns-wrapper>button {
+.confirm-modal-btns-wrapper > button {
   font-size: 1.6rem;
-  color: var(--label-color)
+  color: var(--label-color);
 }
 
-
-.confirm-modal-btns-wrapper>.delete-btn {
-  color: var(--danger-red-color)
+.confirm-modal-btns-wrapper > .delete-btn {
+  color: var(--danger-red-color);
 }
 
-.confirm-modal-btns-wrapper>.add-btn {
-  color: var(--primary-color-3)
+.confirm-modal-btns-wrapper > .add-btn {
+  color: var(--primary-color-3);
 }

--- a/src/frontend/utils/history.js
+++ b/src/frontend/utils/history.js
@@ -1,0 +1,18 @@
+
+export const getHistoryDetailAdderSelects = ($element = document) => {
+  const $categorySelect = $element.querySelector('select[name="category"]');
+  const $paymentSelect = $element.querySelector('select[name="payment"]');
+  return {$categorySelect, $paymentSelect};
+};
+
+export const getHistoryDetailAdderInputs = ($element = document) => {
+  const $dateStringInput = $element.querySelector('input[name="dateString"]');
+  const $descriptionInput = $element.querySelector('input[name="description"]');
+  const $priceInput = $element.querySelector('input[name="price"]');
+  return {$dateStringInput, $descriptionInput, $priceInput};
+};
+
+export const getHistoryDetailAdderItems = ($element = document) => ({
+  ...getHistoryDetailAdderInputs($element),
+  ...getHistoryDetailAdderSelects($element),
+});

--- a/src/frontend/utils/history.js
+++ b/src/frontend/utils/history.js
@@ -16,3 +16,21 @@ export const getHistoryDetailAdderItems = ($element = document) => ({
   ...getHistoryDetailAdderInputs($element),
   ...getHistoryDetailAdderSelects($element),
 });
+
+const initValue = ($elem, defaultValue) => {
+  $elem.dataset.defaultValue = defaultValue;
+  $elem.value = defaultValue;
+};
+
+export const setHistoryDetailAdderForm = ({id, dateString, categoryId, description, paymentId, price}) => {
+  const $historyDetailAdder = document.querySelector('.history-detail-adder');
+  $historyDetailAdder.dataset.id = id;
+  const {$dateStringInput, $categorySelect, $descriptionInput, $paymentSelect, $priceInput} =
+    getHistoryDetailAdderItems($historyDetailAdder);
+
+  initValue($dateStringInput, dateString);
+  initValue($categorySelect, categoryId);
+  initValue($descriptionInput, description);
+  initValue($paymentSelect, paymentId);
+  initValue($priceInput, price);
+};

--- a/src/frontend/utils/history.js
+++ b/src/frontend/utils/history.js
@@ -1,3 +1,6 @@
+/* eslint-disable no-param-reassign */
+/* eslint-disable-next-line import/prefer-default-export */
+import {getTodayDateString} from './date.js';
 
 export const getHistoryDetailAdderSelects = ($element = document) => {
   const $categorySelect = $element.querySelector('select[name="category"]');
@@ -33,4 +36,38 @@ export const setHistoryDetailAdderForm = ({id, dateString, categoryId, descripti
   initValue($descriptionInput, description);
   initValue($paymentSelect, paymentId);
   initValue($priceInput, price);
+};
+
+const removeValue = $elem => {
+  delete $elem.dataset.defaultValue;
+  $elem.value = '';
+};
+
+export const dispatchInputEvent = $element => {
+  const event = new Event('input', {
+    bubbles: true,
+  });
+  $element.dispatchEvent(event);
+};
+
+export const dispatchInputEventToAdderSelects = () => {
+  const event = new Event('input', {
+    bubbles: true,
+  });
+  const {$categorySelect, $paymentSelect} = getHistoryDetailAdderSelects();
+  $categorySelect.dispatchEvent(event);
+  $paymentSelect.dispatchEvent(event);
+};
+
+export const resetHistoryDetailAdderForm = () => {
+  const $historyDetailAdder = document.querySelector('.history-detail-adder');
+  delete $historyDetailAdder.dataset.id;
+  const adderItems = getHistoryDetailAdderItems($historyDetailAdder);
+  Object.values(adderItems).forEach(adderItem => {
+    delete adderItem.value;
+    removeValue(adderItem);
+  });
+  const {$dateStringInput} = adderItems;
+  $dateStringInput.value = getTodayDateString({withDot: false});
+  dispatchInputEventToAdderSelects();
 };

--- a/src/frontend/views/account-history/DetailView.js
+++ b/src/frontend/views/account-history/DetailView.js
@@ -10,13 +10,11 @@ export default class AccountHistoryDetailView {
     $parent.appendChild(this.$target);
 
     this.model = model;
-    this.model.subscribe('history', this.render.bind(this));
 
     this.render();
   }
 
   render() {
-    this.$target.innerHTML = '';
     new AccountHistoryDetailAdder({$parent: this.$target, model: this.model});
     new AccountHistoryDetailList({$parent: this.$target, model: this.model});
   }


### PR DESCRIPTION
## Description

결제수단을 추가/삭제했을 때 DetailAdder의 기존 입력값들이 사라지지 않게 설정합니다.

## Related Issues

resolve #50 

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] Issue TODO finished
- [x] No Conflicts with the base branch
